### PR TITLE
Prepend root path to urlForHelper

### DIFF
--- a/lib/plugins/helper/url_for.js
+++ b/lib/plugins/helper/url_for.js
@@ -26,13 +26,9 @@ function urlForHelper(path, options){
   }
 
   // Prepend root path
-  if(path === '/') {
-    return root;
-  } else if (path[0] !== '/'){
-    return root + path;
-  }
+  path = root + path;
 
-  return path;
+  return path.replace(/\/{2,}/g, '/');
 }
 
 module.exports = urlForHelper;

--- a/test/scripts/helpers/url_for.js
+++ b/test/scripts/helpers/url_for.js
@@ -14,10 +14,12 @@ describe('url_for', function(){
     ctx.config.root = '/';
     urlFor('index.html').should.eql('/index.html');
     urlFor('/').should.eql('/');
+    urlFor('/index.html').should.eql('/index.html');
 
     ctx.config.root = '/blog/';
     urlFor('index.html').should.eql('/blog/index.html');
     urlFor('/').should.eql('/blog/');
+    urlFor('/index.html').should.eql('/blog/index.html');
   });
 
   it('internal url (relative on)', function(){


### PR DESCRIPTION
When user configures a prefix path as root path, urlForHelper can not
resolve url like '/archives' correctly with the prefix root path.

Resolves: #1105
